### PR TITLE
Allow dowel versions >= 0.0.3 so dowel 0.0.4 beta works

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ REQUIRED = [
     'click>=2.0',
     'cloudpickle',
     'cma==2.7.0',
-    'dowel==0.0.3',
+    'dowel>=0.0.3',
     'numpy>=1.14.5',
     'psutil',
     'python-dateutil',


### PR DESCRIPTION
caplett/dowel builds a beta for version 0.0.4, which does not work if the requirements in the setup.py are not loosened.