### PR TITLE
add video logging functionality for evaluation episodes

### DIFF
--- a/src/garage/_functions.py
+++ b/src/garage/_functions.py
@@ -71,6 +71,7 @@ def rollout(env,
             max_episode_length=np.inf,
             animated=False,
             pause_per_frame=None,
+            render_env=False,
             deterministic=False):
     """Sample a single episode of the agent in the environment.
 
@@ -109,6 +110,7 @@ def rollout(env,
     env_steps = []
     agent_infos = []
     observations = []
+    rendered_images = []
     last_obs, episode_infos = env.reset()
     agent.reset()
     episode_length = 0
@@ -124,6 +126,11 @@ def rollout(env,
         env_steps.append(es)
         observations.append(last_obs)
         agent_infos.append(agent_info)
+
+        if render_env:
+            rendered_images.append(np.swapaxes(env.render('human').T, 1, 2))
+
+
         episode_length += 1
         if es.last:
             break
@@ -137,6 +144,8 @@ def rollout(env,
         agent_infos=stack_tensor_dict_list(agent_infos),
         env_infos=stack_tensor_dict_list([es.env_info for es in env_steps]),
         dones=np.array([es.terminal for es in env_steps]),
+        rendered_images = np.array(rendered_images),
+
     )
 
 
@@ -144,6 +153,7 @@ def obtain_evaluation_episodes(policy,
                                env,
                                max_episode_length=1000,
                                num_eps=100,
+                               render_env=False,
                                deterministic=True):
     """Sample the policy for num_eps episodes and return average values.
 
@@ -169,10 +179,20 @@ def obtain_evaluation_episodes(policy,
             eps = rollout(env,
                           policy,
                           max_episode_length=max_episode_length,
+                          render_env = render_env,
                           deterministic=deterministic)
+            if render_env:
+                task_name = env._env._task_name 
+                log_multitask_video(eps, task_name)
+            
             episodes.append(eps)
     return EpisodeBatch.from_list(env.spec, episodes)
 
+
+def log_multitask_video(eps, task_name):
+    video = eps["rendered_images"]
+    with tabular.prefix(task_name + '/'):
+        tabular.record('Video', video)
 
 def log_multitask_performance(itr, batch, discount, name_map=None):
     r"""Log performance of episodes from multiple tasks.

--- a/src/garage/_functions.py
+++ b/src/garage/_functions.py
@@ -182,7 +182,13 @@ def obtain_evaluation_episodes(policy,
                           render_env = render_env,
                           deterministic=deterministic)
             if render_env:
-                task_name = env._env._task_name 
+                task_name = "name_not_found"
+                # Two Layers needed becaue multitask env is other type as single task env
+                if hasattr(env._env, '_task_name'):
+                    task_name = env._env._task_name
+                elif hasattr(env._env, '_env'):
+                    if hasattr(env._env._env, '_task_name'):
+                        task_name = env._env._env._task_name
                 log_multitask_video(eps, task_name)
             
             episodes.append(eps)

--- a/src/garage/torch/algos/mtsac.py
+++ b/src/garage/torch/algos/mtsac.py
@@ -103,6 +103,7 @@ class MTSAC(SAC):
         steps_per_epoch=1,
         num_evaluation_episodes=5,
         use_deterministic_evaluation=True,
+        render_env = False
     ):
 
         super().__init__(
@@ -149,6 +150,7 @@ class MTSAC(SAC):
                                            self._num_tasks).log()
         self._epoch_mean_success_rate = []
         self._epoch_median_success_rate = []
+        self._render_env = render_env
 
     def _get_log_alpha(self, samples_data):
         """Return the value of log_alpha.
@@ -211,6 +213,7 @@ class MTSAC(SAC):
                     eval_env,
                     self._max_episode_length_eval,
                     num_eps=self._num_evaluation_episodes,
+                    render_env = self._render_env,
                     deterministic=self._use_deterministic_evaluation))
         eval_eps = EpisodeBatch.concatenate(*eval_eps)
         last_return = log_multitask_performance(epoch, eval_eps,


### PR DESCRIPTION
This branch adds on option in the evaluation rollout to render videos of the environment add write them as a ndarray to a logger