### PR TITLE
use the same device for obs as for z.

### DIFF
--- a/src/garage/torch/policies/context_conditioned_policy.py
+++ b/src/garage/torch/policies/context_conditioned_policy.py
@@ -211,6 +211,8 @@ class ContextConditionedPolicy(nn.Module):
         """
         z = self.z
         obs = torch.as_tensor(obs[None], device=global_device()).float()
+        obs = obs.to(z.device)
+
         obs_in = torch.cat([obs, z], dim=1)
         action, info = self._policy.get_action(obs_in)
         return action, info


### PR DESCRIPTION
This is a fix but should work for now.
The GPU is utilized at nearly 100% if this is used.