### PR TITLE
add fisher linear discriminant analysis for pearl latent space.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ REQUIRED = [
     'ray',
     'scikit-image',
     'scipy',
+    'sklearn',
     'setproctitle>=1.0',
     'torch>=1.0.0,!=1.5.0,<1.8.0',
     'torchvision>=0.2.1,<=0.8.2',

--- a/src/garage/_dtypes.py
+++ b/src/garage/_dtypes.py
@@ -181,7 +181,7 @@ class TimeStep:
                    step_type=env_step.step_type)
 
 
-@dataclass(frozen=True)
+@dataclass()
 class TimeStepBatch:
     # pylint: disable=missing-param-doc, missing-type-doc
     """A tuple representing a batch of TimeSteps.
@@ -451,7 +451,7 @@ class TimeStepBatch:
         return TimeStepBatch.concatenate(*ts_batches)
 
 
-@dataclass(frozen=True, init=False)
+@dataclass(init=False)
 class EpisodeBatch(TimeStepBatch):
     # pylint: disable=missing-return-doc, missing-return-type-doc, missing-param-doc, missing-type-doc  # noqa: E501
     r"""A tuple representing a batch of whole episodes.

--- a/src/garage/experiment/experiment.py
+++ b/src/garage/experiment/experiment.py
@@ -328,7 +328,7 @@ class ExperimentTemplate:
         logger.add_output(
             dowel.TensorBoardOutput(log_dir, x_axis=options['x_axis']))
         logger.add_output(
-            dowel.WandBOutput(x_axis=options['x_axis']))
+            dowel.WandBOutput())
         logger.add_output(dowel.StdOutput())
 
         logger.push_prefix('[{}] '.format(name))

--- a/src/garage/experiment/meta_evaluator.py
+++ b/src/garage/experiment/meta_evaluator.py
@@ -100,6 +100,7 @@ class MetaEvaluator:
                 self._eval_itr,
                 test_episodes_per_task * self._max_episode_length,
                 adapted_policy)
+            adapted_eps.z = adapted_policy.z.cpu().detach().numpy()[0]
             adapted_episodes.append(adapted_eps)
         logger.log('Finished meta-testing...')
 
@@ -111,7 +112,7 @@ class MetaEvaluator:
         with tabular.prefix(self._prefix + '/' if self._prefix else ''):
             log_multitask_performance(
                 self._eval_itr,
-                EpisodeBatch.concatenate(*adapted_episodes),
+                adapted_episodes,
                 getattr(algo, 'discount', 1.0),
                 name_map=name_map)
         self._eval_itr += 1


### PR DESCRIPTION
This PR adds visualisation for the pearl latent space.

It uses a hack to not adapt EpisodeBatch datastructure:

1. make EpisodeBatch non const and assigne the latent values imperative as member value
2. remove concatenate and batch.split() from evaluation functions.

The visualisation is done with a frisher linear discriminant analysis. This could maybe be changed in the future because it might show the latent space better than it is. It also only works for >=2 samples per evaluation task.