### PR TITLE
Rendering for PEARL

### DIFF
--- a/src/garage/__init__.py
+++ b/src/garage/__init__.py
@@ -5,6 +5,7 @@ from garage._dtypes import EpisodeBatch, TimeStep, TimeStepBatch
 from garage._environment import (Environment, EnvSpec, EnvStep, InOutSpec,
                                  StepType, Wrapper)
 from garage._functions import (_Default, log_multitask_performance,
+                               log_multitask_video,
                                log_performance, make_optimizer,
                                obtain_evaluation_episodes, rollout)
 from garage.experiment.experiment import wrap_experiment
@@ -19,6 +20,7 @@ __all__ = [
     'TimeStep',
     'EpisodeBatch',
     'log_multitask_performance',
+    'log_multitask_video',
     'log_performance',
     'InOutSpec',
     'TimeStepBatch',

--- a/src/garage/_dtypes.py
+++ b/src/garage/_dtypes.py
@@ -1062,9 +1062,10 @@ def check_timestep_batch(batch, array_type, ignored_fields=()):
                         f'{env_spec.observation_space}')
                 if (isinstance(value[0], np.ndarray)
                         and not env_spec.observation_space.contains(value[0])):
-                    warnings.warn(
-                        f'Observation {value[0]!r} is outside '
-                        f'observation_space {env_spec.observation_space}')
+                    pass
+                    #warnings.warn(
+                    #    f'Observation {value[0]!r} is outside '
+                    #    f'observation_space {env_spec.observation_space}')
             if env_spec and field == 'actions':
                 if not _space_soft_contains(env_spec.action_space, value[0]):
                     raise ValueError(

--- a/src/garage/_dtypes.py
+++ b/src/garage/_dtypes.py
@@ -1062,10 +1062,9 @@ def check_timestep_batch(batch, array_type, ignored_fields=()):
                         f'{env_spec.observation_space}')
                 if (isinstance(value[0], np.ndarray)
                         and not env_spec.observation_space.contains(value[0])):
-                    pass
-                    #warnings.warn(
-                    #    f'Observation {value[0]!r} is outside '
-                    #    f'observation_space {env_spec.observation_space}')
+                    warnings.warn(
+                        f'Observation {value[0]!r} is outside '
+                        f'observation_space {env_spec.observation_space}')
             if env_spec and field == 'actions':
                 if not _space_soft_contains(env_spec.action_space, value[0]):
                     raise ValueError(

--- a/src/garage/_dtypes.py
+++ b/src/garage/_dtypes.py
@@ -525,12 +525,12 @@ class EpisodeBatch(TimeStepBatch):
     """
     episode_infos_by_episode: np.ndarray
     last_observations: np.ndarray
-    rendered_images: np.array
+    rendered_images: np.ndarray
     lengths: np.ndarray
 
     def __init__(self, env_spec, episode_infos, observations,
                  last_observations, actions, rewards, env_infos, agent_infos,
-                 step_types, lengths, rendered_images = []):  # noqa: D102
+                 step_types, lengths, rendered_images = np.asarray([])):  # noqa: D102
         # lengths
         if len(lengths.shape) != 1:
             raise ValueError(
@@ -634,7 +634,8 @@ class EpisodeBatch(TimeStepBatch):
             agent_infos=agent_infos,
             step_types=np.concatenate([batch.step_types for batch in batches]),
             lengths=np.concatenate([batch.lengths for batch in batches]),
-            rendered_images=[batch.rendered_images for batch in batches])
+            rendered_images=np.concatenate([batch.rendered_images for batch in batches])
+        )
 
     def _episode_ranges(self):
         """Iterate through start and stop indices for each episode.

--- a/src/garage/_dtypes.py
+++ b/src/garage/_dtypes.py
@@ -527,7 +527,7 @@ class EpisodeBatch(TimeStepBatch):
 
     def __init__(self, env_spec, episode_infos, observations,
                  last_observations, actions, rewards, env_infos, agent_infos,
-                 step_types, lengths):  # noqa: D102
+                 step_types, lengths, rendered_images = []):  # noqa: D102
         # lengths
         if len(lengths.shape) != 1:
             raise ValueError(
@@ -583,6 +583,7 @@ class EpisodeBatch(TimeStepBatch):
         object.__setattr__(self, 'env_infos', env_infos)
         object.__setattr__(self, 'agent_infos', agent_infos)
         object.__setattr__(self, 'step_types', step_types)
+        object.__setattr__(self, 'rendered_images', rendered_images)
         check_timestep_batch(
             self,
             np.ndarray,

--- a/src/garage/_functions.py
+++ b/src/garage/_functions.py
@@ -196,7 +196,6 @@ def obtain_evaluation_episodes(policy,
 
 
 def log_multitask_video(eps, task_name):
-    # pdb.set_trace()
     video = eps["rendered_images"]
     if (type(video) is list) and len(video) == 0: 
         return

--- a/src/garage/_functions.py
+++ b/src/garage/_functions.py
@@ -196,9 +196,15 @@ def obtain_evaluation_episodes(policy,
 
 
 def log_multitask_video(eps, task_name):
+    # pdb.set_trace()
     video = eps["rendered_images"]
-    with tabular.prefix(task_name + '/'):
-        tabular.record('Video', video)
+    if (type(video) is list) and len(video) == 0: 
+        return
+    elif (type(video) is np.ndarray) and video.size == 0: 
+        return
+    else:
+        with tabular.prefix(task_name + '/'):
+            tabular.record('Video', video)
 
 def log_multitask_performance(itr, batch, discount, name_map=None):
     r"""Log performance of episodes from multiple tasks.

--- a/src/garage/experiment/meta_evaluator.py
+++ b/src/garage/experiment/meta_evaluator.py
@@ -2,7 +2,7 @@
 
 from dowel import logger, tabular
 
-from garage import EpisodeBatch, log_multitask_performance
+from garage import EpisodeBatch, log_multitask_performance, log_multitask_video
 from garage.experiment.deterministic import get_seed
 from garage.sampler import DefaultWorker, LocalSampler, WorkerFactory
 
@@ -46,7 +46,8 @@ class MetaEvaluator:
                  prefix='MetaTest',
                  test_task_names=None,
                  worker_class=DefaultWorker,
-                 worker_args=None):
+                 worker_args=None,
+                 render_env=False):
         self._test_task_sampler = test_task_sampler
         self._worker_class = worker_class
         if worker_args is None:
@@ -63,6 +64,7 @@ class MetaEvaluator:
         self._test_task_names = test_task_names
         self._test_sampler = None
         self._max_episode_length = None
+        self._render_env = render_env
 
     def evaluate(self, algo, test_episodes_per_task=None):
         """Evaluate the Meta-RL algorithm on the test tasks.
@@ -99,7 +101,8 @@ class MetaEvaluator:
             adapted_eps = self._test_sampler.obtain_samples(
                 self._eval_itr,
                 test_episodes_per_task * self._max_episode_length,
-                adapted_policy)
+                adapted_policy,
+                render_env=self._render_env)
             adapted_episodes.append(adapted_eps)
         logger.log('Finished meta-testing...')
 
@@ -114,4 +117,16 @@ class MetaEvaluator:
                 EpisodeBatch.concatenate(*adapted_episodes),
                 getattr(algo, 'discount', 1.0),
                 name_map=name_map)
+
+        if self._render_env:
+            for epbatches in adapted_episodes:
+                for eps in epbatches:
+                    task_name = '__unnamed_task__' 
+                    if 'task_name' in eps.env_infos:
+                        task_name = eps.env_infos['task_name'][0]
+                    elif 'task_id' in eps.env_infos:
+                        task_id = eps.env_infos['task_id'][0]
+                        task_name = name_map.get(task_id, 'Task #{}'.format(task_id))
+                    log_multitask_video(eps, task_name)
+
         self._eval_itr += 1

--- a/src/garage/experiment/meta_evaluator.py
+++ b/src/garage/experiment/meta_evaluator.py
@@ -119,14 +119,13 @@ class MetaEvaluator:
                 name_map=name_map)
 
         if self._render_env:
-            for epbatches in adapted_episodes:
-                for eps in epbatches:
-                    task_name = '__unnamed_task__' 
-                    if 'task_name' in eps.env_infos:
-                        task_name = eps.env_infos['task_name'][0]
-                    elif 'task_id' in eps.env_infos:
-                        task_id = eps.env_infos['task_id'][0]
-                        task_name = name_map.get(task_id, 'Task #{}'.format(task_id))
-                    log_multitask_video(eps, task_name)
+            for eps in EpisodeBatch.concatenate(*adapted_episodes).to_list():
+                task_name = '__unnamed_task__' 
+                if 'task_name' in eps.env_infos:
+                    task_name = eps.env_infos['task_name'][0]
+                elif 'task_id' in eps.env_infos:
+                    task_id = eps.env_infos['task_id'][0]
+                    task_name = name_map.get(task_id, 'Task #{}'.format(task_id))
+                log_multitask_video(eps, task_name)
 
         self._eval_itr += 1

--- a/src/garage/experiment/meta_evaluator.py
+++ b/src/garage/experiment/meta_evaluator.py
@@ -120,11 +120,12 @@ class MetaEvaluator:
 
         if self._render_env:
             for eps in EpisodeBatch.concatenate(*adapted_episodes).to_list():
+                env_infos = eps['env_infos']
                 task_name = '__unnamed_task__' 
-                if 'task_name' in eps.env_infos:
-                    task_name = eps.env_infos['task_name'][0]
-                elif 'task_id' in eps.env_infos:
-                    task_id = eps.env_infos['task_id'][0]
+                if 'task_name' in env_infos:
+                    task_name = env_infos['task_name'][0]
+                elif 'task_id' in env_infos:
+                    task_id = env_infos['task_id'][0]
                     task_name = name_map.get(task_id, 'Task #{}'.format(task_id))
                 log_multitask_video(eps, task_name)
 

--- a/src/garage/sampler/default_worker.py
+++ b/src/garage/sampler/default_worker.py
@@ -8,7 +8,6 @@ from garage.experiment import deterministic
 from garage.sampler import _apply_env_update
 from garage.sampler.worker import Worker
 
-
 class DefaultWorker(Worker):
     """Initialize a worker.
 
@@ -116,7 +115,8 @@ class DefaultWorker(Worker):
                 self._agent_infos[k].append(v)
 
             if render_env:
-                self._rendered_images.append(np.swapaxes(self.env.render('human').T, 1, 2))
+                # self._rendered_images.append(np.swapaxes(self.env.render('human').T, 1, 2))
+                pass
 
             self._eps_length += 1
 

--- a/src/garage/sampler/default_worker.py
+++ b/src/garage/sampler/default_worker.py
@@ -116,7 +116,7 @@ class DefaultWorker(Worker):
                 self._agent_infos[k].append(v)
 
             if render_env:
-                self._rendered_images.append(np.swapaxes(self.env.render('human').T, 1, 2))
+                self._rendered_images.append(np.swapaxes(self.env.render('rgb_array').T, 1, 2))
 
             self._eps_length += 1
 

--- a/src/garage/sampler/default_worker.py
+++ b/src/garage/sampler/default_worker.py
@@ -89,7 +89,12 @@ class DefaultWorker(Worker):
         self.env, _ = _apply_env_update(self.env, env_update)
 
     def start_episode(self, render_env=False):
-        """Begin a new episode."""
+        """Begin a new episode.
+
+        Args:
+            render_env (bool): Decides whether to render the rolled out sample
+                into a sequence of images.
+        """
         self._eps_length = 0
         self._rendered_images = []
         self._prev_obs, episode_info = self.env.reset()
@@ -100,6 +105,10 @@ class DefaultWorker(Worker):
 
     def step_episode(self, render_env=False):
         """Take a single time-step in the current episode.
+
+        Args:
+            render_env (bool): Decides whether to render the rolled out sample
+                into a sequence of images.
 
         Returns:
             bool: True iff the episode is done, either due to the environment
@@ -114,10 +123,6 @@ class DefaultWorker(Worker):
             for k, v in agent_info.items():
                 self._agent_infos[k].append(v)
 
-            if render_env:
-                # self._rendered_images.append(np.swapaxes(self.env.render('human').T, 1, 2))
-                pass
-
             self._eps_length += 1
 
             if not es.terminal:
@@ -129,6 +134,10 @@ class DefaultWorker(Worker):
 
     def collect_episode(self, render_env=False):
         """Collect the current episode, clearing the internal buffer.
+
+        Args:
+            render_env (bool): Decides whether to render the rolled out sample
+                into a sequence of images.
 
         Returns:
             EpisodeBatch: A batch of the episodes completed since the last call

--- a/src/garage/sampler/default_worker.py
+++ b/src/garage/sampler/default_worker.py
@@ -92,7 +92,7 @@ class DefaultWorker(Worker):
     def start_episode(self, render_env=False):
         """Begin a new episode."""
         self._eps_length = 0
-        self._renderer_images = []
+        self._rendered_images = []
         self._prev_obs, episode_info = self.env.reset()
         for k, v in episode_info.items():
             self._episode_infos[k].append(v)
@@ -116,7 +116,7 @@ class DefaultWorker(Worker):
                 self._agent_infos[k].append(v)
 
             if render_env:
-                self._rendered_images.append(np.swapaxes(self._env.render('human').T, 1, 2))
+                self._rendered_images.append(np.swapaxes(self.env.render('human').T, 1, 2))
 
             self._eps_length += 1
 
@@ -139,6 +139,8 @@ class DefaultWorker(Worker):
         self._observations = []
         last_observations = self._last_observations
         self._last_observations = []
+        rendered_images = self._rendered_images
+        self._rendered_images = []
 
         actions = []
         rewards = []
@@ -178,10 +180,14 @@ class DefaultWorker(Worker):
                             env_infos=dict(env_infos),
                             agent_infos=dict(agent_infos),
                             lengths=np.asarray(lengths, dtype='i'),
-                            rendered_images=np.array(self._rendered_images))
+                            rendered_images=np.array(rendered_images))
 
     def rollout(self, render_env=False):
         """Sample a single episode of the agent in the environment.
+
+        Args:
+            render_env (bool): Decides whether to render the rolled out sample
+                into a sequence of images.
 
         Returns:
             EpisodeBatch: The collected episode.

--- a/src/garage/sampler/default_worker.py
+++ b/src/garage/sampler/default_worker.py
@@ -116,7 +116,7 @@ class DefaultWorker(Worker):
                 self._agent_infos[k].append(v)
 
             if render_env:
-                self._rendered_images.append(np.swapaxes(self.env.render('rgb_array').T, 1, 2))
+                self._rendered_images.append(np.swapaxes(self.env.render('human').T, 1, 2))
 
             self._eps_length += 1
 

--- a/src/garage/sampler/fragment_worker.py
+++ b/src/garage/sampler/fragment_worker.py
@@ -47,7 +47,6 @@ class FragmentWorker(DefaultWorker):
         self._agents = [None] * n_envs
         self._episode_lengths = [0] * self._n_envs
         self._complete_fragments = []
-        self._rendered_images = []
         # Initialized in start_episode
         self._fragments = None
 
@@ -87,7 +86,6 @@ class FragmentWorker(DefaultWorker):
     def start_episode(self, render_env=False):
         """Resets all agents if the environment was updated."""
         if self._needs_env_reset:
-            self._rendered_images = []
             self._needs_env_reset = False
             self.agent.reset([True] * len(self._envs))
             self._episode_lengths = [0] * len(self._envs)

--- a/src/garage/sampler/fragment_worker.py
+++ b/src/garage/sampler/fragment_worker.py
@@ -47,6 +47,7 @@ class FragmentWorker(DefaultWorker):
         self._agents = [None] * n_envs
         self._episode_lengths = [0] * self._n_envs
         self._complete_fragments = []
+        self._rendered_images = []
         # Initialized in start_episode
         self._fragments = None
 
@@ -83,15 +84,16 @@ class FragmentWorker(DefaultWorker):
                     self._envs[env_index], env_up)
                 self._needs_env_reset |= up
 
-    def start_episode(self):
+    def start_episode(self, render_env=False):
         """Resets all agents if the environment was updated."""
         if self._needs_env_reset:
+            self._rendered_images = []
             self._needs_env_reset = False
             self.agent.reset([True] * len(self._envs))
             self._episode_lengths = [0] * len(self._envs)
             self._fragments = [InProgressEpisode(env) for env in self._envs]
 
-    def step_episode(self):
+    def step_episode(self, render_env=False):
         """Take a single time-step in the current episode.
 
         Returns:
@@ -118,7 +120,7 @@ class FragmentWorker(DefaultWorker):
             self.agent.reset(completes)
         return any(completes)
 
-    def collect_episode(self):
+    def collect_episode(self, render_env=False):
         """Gather fragments from all in-progress episodes.
 
         Returns:
@@ -137,17 +139,17 @@ class FragmentWorker(DefaultWorker):
         self._complete_fragments = []
         return result
 
-    def rollout(self):
+    def rollout(self, render_env=False):
         """Sample a single episode of the agent in the environment.
 
         Returns:
             EpisodeBatch: The collected episode.
 
         """
-        self.start_episode()
+        self.start_episode(render_env)
         for _ in range(self._timesteps_per_call):
-            self.step_episode()
-        complete_frag = self.collect_episode()
+            self.step_episode(render_env)
+        complete_frag = self.collect_episode(render_env)
         return complete_frag
 
     def shutdown(self):

--- a/src/garage/sampler/fragment_worker.py
+++ b/src/garage/sampler/fragment_worker.py
@@ -84,7 +84,13 @@ class FragmentWorker(DefaultWorker):
                 self._needs_env_reset |= up
 
     def start_episode(self, render_env=False):
-        """Resets all agents if the environment was updated."""
+        """Resets all agents if the environment was updated.
+
+        Args:
+            render_env (bool): Whether the worker should render frames to
+                rendered_frames. NOT IMPLEMENTED YET. See the PEARLWorker
+                for reference.
+        """
         if self._needs_env_reset:
             self._needs_env_reset = False
             self.agent.reset([True] * len(self._envs))
@@ -93,6 +99,11 @@ class FragmentWorker(DefaultWorker):
 
     def step_episode(self, render_env=False):
         """Take a single time-step in the current episode.
+
+        Args:
+            render_env (bool): Whether the worker should render frames to
+                rendered_frames. NOT IMPLEMENTED YET. See the PEARLWorker
+                for reference.
 
         Returns:
             bool: True iff at least one of the episodes was completed.
@@ -121,6 +132,11 @@ class FragmentWorker(DefaultWorker):
     def collect_episode(self, render_env=False):
         """Gather fragments from all in-progress episodes.
 
+        Args:
+            render_env (bool): Whether the worker should render frames to
+                rendered_frames. NOT IMPLEMENTED YET. See the PEARLWorker
+                for reference.
+
         Returns:
             EpisodeBatch: A batch of the episode fragments.
 
@@ -139,6 +155,11 @@ class FragmentWorker(DefaultWorker):
 
     def rollout(self, render_env=False):
         """Sample a single episode of the agent in the environment.
+
+        Args:
+            render_env (bool): Whether the worker should render frames to
+                rendered_frames. NOT IMPLEMENTED YET. See the PEARLWorker
+                for reference.
 
         Returns:
             EpisodeBatch: The collected episode.

--- a/src/garage/sampler/local_sampler.py
+++ b/src/garage/sampler/local_sampler.py
@@ -170,7 +170,8 @@ class LocalSampler(Sampler):
     def obtain_exact_episodes(self,
                               n_eps_per_worker,
                               agent_update,
-                              env_update=None):
+                              env_update=None,
+                              render_env=False):
         """Sample an exact number of episodes per worker.
 
         Args:
@@ -184,6 +185,8 @@ class LocalSampler(Sampler):
                 `env_update_fn` before samplin episodes. If a list is passed
                 in, it must have length exactly `factory.n_workers`, and will
                 be spread across the workers.
+            render_env (bool): Whether to render the rolled out episode as a
+                sequence of images.
 
         Returns:
             EpisodeBatch: Batch of gathered episodes. Always in worker
@@ -195,7 +198,7 @@ class LocalSampler(Sampler):
         batches = []
         for worker in self._workers:
             for _ in range(n_eps_per_worker):
-                batch = worker.rollout()
+                batch = worker.rollout(render_env=render_env)
                 batches.append(batch)
         samples = EpisodeBatch.concatenate(*batches)
         self.total_env_steps += sum(samples.lengths)

--- a/src/garage/sampler/local_sampler.py
+++ b/src/garage/sampler/local_sampler.py
@@ -131,7 +131,7 @@ class LocalSampler(Sampler):
             worker.update_agent(agent_up)
             worker.update_env(env_up)
 
-    def obtain_samples(self, itr, num_samples, agent_update, env_update=None):
+    def obtain_samples(self, itr, num_samples, agent_update, env_update=None, render_env=False):
         """Collect at least a given number transitions (timesteps).
 
         Args:
@@ -147,6 +147,7 @@ class LocalSampler(Sampler):
                 `env_update_fn` before sampling episodes. If a list is passed
                 in, it must have length exactly `factory.n_workers`, and will
                 be spread across the workers.
+            render_env (bool): Whether to render the sample as a sequence of images.
 
         Returns:
             EpisodeBatch: The batch of collected episodes.
@@ -157,7 +158,7 @@ class LocalSampler(Sampler):
         completed_samples = 0
         while True:
             for worker in self._workers:
-                batch = worker.rollout()
+                batch = worker.rollout(render_env)
                 completed_samples += len(batch.actions)
                 batches.append(batch)
                 if completed_samples >= num_samples:

--- a/src/garage/sampler/local_sampler.py
+++ b/src/garage/sampler/local_sampler.py
@@ -147,7 +147,8 @@ class LocalSampler(Sampler):
                 `env_update_fn` before sampling episodes. If a list is passed
                 in, it must have length exactly `factory.n_workers`, and will
                 be spread across the workers.
-            render_env (bool): Whether to render the sample as a sequence of images.
+            render_env (bool): Whether to render the rolled out episode as a
+                sequence of images.
 
         Returns:
             EpisodeBatch: The batch of collected episodes.
@@ -158,7 +159,7 @@ class LocalSampler(Sampler):
         completed_samples = 0
         while True:
             for worker in self._workers:
-                batch = worker.rollout(render_env)
+                batch = worker.rollout(render_env=render_env)
                 completed_samples += len(batch.actions)
                 batches.append(batch)
                 if completed_samples >= num_samples:

--- a/src/garage/sampler/multiprocessing_sampler.py
+++ b/src/garage/sampler/multiprocessing_sampler.py
@@ -161,7 +161,7 @@ class MultiprocessingSampler(Sampler):
                 except queue.Full:
                     pass
 
-    def obtain_samples(self, itr, num_samples, agent_update, env_update=None):
+    def obtain_samples(self, itr, num_samples, agent_update, env_update=None, render_env=False):
         """Collect at least a given number transitions (timesteps).
 
         Args:

--- a/src/garage/sampler/multiprocessing_sampler.py
+++ b/src/garage/sampler/multiprocessing_sampler.py
@@ -177,6 +177,8 @@ class MultiprocessingSampler(Sampler):
                 `env_update_fn` before sampling episodes. If a list is passed
                 in, it must have length exactly `factory.n_workers`, and will
                 be spread across the workers.
+            render_env (bool): Whether to render the rolled out episode as a
+                sequence of images. NOT USED YET, CHECK LOCALSAMPLER FOR REFERENCE.
 
         Returns:
             EpisodeBatch: The batch of collected episodes.
@@ -232,7 +234,8 @@ class MultiprocessingSampler(Sampler):
     def obtain_exact_episodes(self,
                               n_eps_per_worker,
                               agent_update,
-                              env_update=None):
+                              env_update=None,
+                              render_env=False):
         """Sample an exact number of episodes per worker.
 
         Args:
@@ -246,6 +249,8 @@ class MultiprocessingSampler(Sampler):
                 `env_update_fn` before sampling episodes. If a list is passed
                 in, it must have length exactly `factory.n_workers`, and will
                 be spread across the workers.
+            render_env (bool): Whether to render the rolled out episode as a
+                sequence of images. NOT USED YET, CHECK LOCALSAMPLER FOR REFERENCE.
 
         Returns:
             EpisodeBatch: Batch of gathered episodes. Always in worker

--- a/src/garage/sampler/ray_sampler.py
+++ b/src/garage/sampler/ray_sampler.py
@@ -196,7 +196,7 @@ class RaySampler(Sampler):
                 while idle_worker_ids:
                     idle_worker_id = idle_worker_ids.pop()
                     worker = self._all_workers[idle_worker_id]
-                    active_workers.append(worker.rollout.remote())
+                    active_workers.append(worker.rollout.remote(render_env=render_env))
 
                 # check which workers are done/not done collecting a sample
                 # if any are done, send them to process the collected
@@ -220,7 +220,8 @@ class RaySampler(Sampler):
     def obtain_exact_episodes(self,
                               n_eps_per_worker,
                               agent_update,
-                              env_update=None):
+                              env_update=None,
+                              render_env=False):
         """Sample an exact number of episodes per worker.
 
         Args:
@@ -234,6 +235,8 @@ class RaySampler(Sampler):
                 `env_update_fn` before sampling episodes. If a list is passed
                 in, it must have length exactly `factory.n_workers`, and will
                 be spread across the workers.
+            render_env (bool): Whether to render the rolled out episode as a
+                sequence of images.
 
         Returns:
             EpisodeBatch: Batch of gathered episodes. Always in worker
@@ -270,7 +273,7 @@ class RaySampler(Sampler):
                 while idle_worker_ids:
                     idle_worker_id = idle_worker_ids.pop()
                     worker = self._all_workers[idle_worker_id]
-                    active_workers.append(worker.rollout.remote())
+                    active_workers.append(worker.rollout.remote(render_env=render_env))
 
                 # check which workers are done/not done collecting a sample
                 # if any are done, send them to process the collected episode
@@ -362,11 +365,15 @@ class SamplerWorker:
     def rollout(self, render_env=False):
         """Sample one episode of the agent in the environment.
 
+        Args:
+            render_env (bool): Whether to render the rolled out episode as a
+                sequence of images.
+
         Returns:
             tuple[int, EpisodeBatch]: Worker ID and batch of samples.
 
         """
-        return (self.worker_id, self.inner_worker.rollout())
+        return (self.worker_id, self.inner_worker.rollout(render_env=render_env))
 
     def shutdown(self):
         """Shuts down the worker."""

--- a/src/garage/sampler/ray_sampler.py
+++ b/src/garage/sampler/ray_sampler.py
@@ -148,7 +148,7 @@ class RaySampler(Sampler):
                 worker.update.remote(param_ids[worker_id], env_ids[worker_id]))
         return updating_workers
 
-    def obtain_samples(self, itr, num_samples, agent_update, env_update=None):
+    def obtain_samples(self, itr, num_samples, agent_update, env_update=None, render_env=False):
         """Sample the policy for new episodes.
 
         Args:

--- a/src/garage/sampler/ray_sampler.py
+++ b/src/garage/sampler/ray_sampler.py
@@ -162,6 +162,8 @@ class RaySampler(Sampler):
                 `env_update_fn` before sampling episodes. If a list is passed
                 in, it must have length exactly `factory.n_workers`, and will
                 be spread across the workers.
+            render_env (bool): Decides whether the rolled out episode should
+                be rendered as images. NOT USED YET!
 
         Returns:
             EpisodeBatch: Batch of gathered episodes.
@@ -357,7 +359,7 @@ class SamplerWorker:
         self.inner_worker.update_env(env_update)
         return self.worker_id
 
-    def rollout(self):
+    def rollout(self, render_env=False):
         """Sample one episode of the agent in the environment.
 
         Returns:

--- a/src/garage/sampler/sampler.py
+++ b/src/garage/sampler/sampler.py
@@ -85,6 +85,8 @@ class Sampler(abc.ABC):
                 `env_update_fn` before sampling episodes. If a list is passed
                 in, it must have length exactly `factory.n_workers`, and will
                 be spread across the workers.
+            render_env (bool): Decides whether the rolled out episodes should
+                be rendered as images.
 
         Returns:
             EpisodeBatch: The batch of collected episodes.

--- a/src/garage/sampler/sampler.py
+++ b/src/garage/sampler/sampler.py
@@ -70,7 +70,7 @@ class Sampler(abc.ABC):
         """
 
     @abc.abstractmethod
-    def obtain_samples(self, itr, num_samples, agent_update, env_update=None):
+    def obtain_samples(self, itr, num_samples, agent_update, env_update=None, render_env=False):
         """Collect at least a given number transitions :class:`TimeStep`s.
 
         Args:

--- a/src/garage/sampler/vec_worker.py
+++ b/src/garage/sampler/vec_worker.py
@@ -104,8 +104,14 @@ class VecWorker(DefaultWorker):
                     self._envs[env_index], env_up)
                 self._needs_env_reset |= up
 
-    def start_episode(self):
-        """Begin a new episode."""
+    def start_episode(self, render_env=False):
+        """Begin a new episode.
+
+        Args:
+            render_env (bool): Whether the worker should render frames to
+                rendered_frames. NOT IMPLEMENTED YET. See the PEARLWorker
+                for reference.
+        """
         if self._needs_agent_reset or self._needs_env_reset:
             n = len(self._envs)
             self.agent.reset([True] * n)
@@ -173,8 +179,13 @@ class VecWorker(DefaultWorker):
         self._agent_infos[episode_number] = collections.defaultdict(list)
         self._episode_infos[episode_number] = collections.defaultdict(list)
 
-    def step_episode(self):
+    def step_episode(self, render_env=False):
         """Take a single time-step in the current episode.
+
+        Args:
+            render_env (bool): Whether the worker should render frames to
+                rendered_frames. NOT IMPLEMENTED YET. See the PEARLWorker
+                for reference.
 
         Returns:
             bool: True iff at least one of the episodes was completed.
@@ -203,8 +214,13 @@ class VecWorker(DefaultWorker):
             self.agent.reset(completes)
         return finished
 
-    def collect_episode(self):
+    def collect_episode(self, render_env=False):
         """Collect all completed episodes.
+
+        Args:
+            render_env (bool): Whether the worker should render frames to
+                rendered_frames. NOT IMPLEMENTED YET. See the PEARLWorker
+                for reference.
 
         Returns:
             EpisodeBatch: A batch of the episodes completed since the last call

--- a/src/garage/sampler/worker.py
+++ b/src/garage/sampler/worker.py
@@ -43,7 +43,7 @@ class Worker(abc.ABC):
 
         """
 
-    def rollout(self):
+    def rollout(self, render_env=False):
         """Sample a single episode of the agent in the environment.
 
         Returns:

--- a/src/garage/sampler/worker.py
+++ b/src/garage/sampler/worker.py
@@ -46,6 +46,10 @@ class Worker(abc.ABC):
     def rollout(self, render_env=False):
         """Sample a single episode of the agent in the environment.
 
+        Args:
+            render_env (bool): Decides whether to render the rolled out sample
+                into a sequence of images.
+
         Returns:
             EpisodeBatch: Batch of sampled episodes. May be truncated if
                 max_episode_length is set.

--- a/src/garage/torch/algos/pearl.py
+++ b/src/garage/torch/algos/pearl.py
@@ -754,7 +754,7 @@ class PEARLWorker(DefaultWorker):
                 self._agent_infos[k].append(v)
 
             if render_env:
-                self._rendered_images.append(np.swapaxes(self.env.render('rgb_array').T, 1, 2))
+                self._rendered_images.append(np.swapaxes(self.env.render('human').T, 1, 2))
 
             self._eps_length += 1
 

--- a/src/garage/torch/algos/pearl.py
+++ b/src/garage/torch/algos/pearl.py
@@ -132,7 +132,8 @@ class PEARL(MetaRLAlgorithm):
             discount=0.99,
             replay_buffer_size=1000000,
             reward_scale=1,
-            update_post_train=1):
+            update_post_train=1,
+            render_env=False):
 
         self._env = env
         self._qf1 = qf
@@ -181,7 +182,8 @@ class PEARL(MetaRLAlgorithm):
         self._evaluator = MetaEvaluator(test_task_sampler=test_env_sampler,
                                         worker_class=PEARLWorker,
                                         worker_args=worker_args,
-                                        n_test_tasks=num_test_tasks)
+                                        n_test_tasks=num_test_tasks,
+                                        render_env=render_env)
 
         encoder_spec = self.get_env_spec(self._single_env, latent_dim,
                                          'encoder')

--- a/src/garage/torch/algos/pearl.py
+++ b/src/garage/torch/algos/pearl.py
@@ -754,7 +754,7 @@ class PEARLWorker(DefaultWorker):
                 self._agent_infos[k].append(v)
 
             if render_env:
-                self._rendered_images.append(np.swapaxes(self.env.render('human').T, 1, 2))
+                self._rendered_images.append(np.swapaxes(self.env.render('rgb_array').T, 1, 2))
 
             self._eps_length += 1
 


### PR DESCRIPTION
Architecture:
PEARL -> MetaEvaluator -> Sampler -> Worker -> OpenAI::render()

- On initializing PEARL, render_env can be set to true
- render_env is passed to the MetaEvaluator since rendering should only take place during evaluation
- MetaEvaluator passes render_env to the sampler via obtain_samples and logs the result using log_multitask_video
- log_multitask_video is extended to check for empty frame arrays before trying to log
- render_env is passed from the sampler (obtain_samples()) to the worker (rollout()) (PEARLworker in this case)
- the PEARL worker actually makes use of render_env and fills the frame array with rendered frames when rolling out the episode
- the EpisodeBatch data structure is extended to hold the rendered_frames array and operate on it (concat, to_list, split...)

Tested on the cluster using the RaySampler, but the LocalSampler should work as well. This implementation is not 100% clean since the various samplers and workers do not all make use of the render_env parameter - I focused on the RaySampler, the LocalSampler, the DefaultWorker and the PEARLWorker to make this work for PEARL specifically.

The FragmentWorker, VecWorker and MultiprocessingSampler should be able to take the render_env parameter without crashing, but they will just do nothing with it. I made it optional everywhere too. I left some comments in the code for future reference. If this is ever going to be used beyond the scope of the internship or merged upstream, this needs to be cleaned up and thoroughly tested for all the various workers/samplers/algorithms to get consistent results. Also, none of this should interfere with SAC rendering since that doesn't even use the MetaEvaluator to begin with.

tl;dr: Rendering that works for PEARL, but needs to be streamlined and cleaned up to work with the various workers and samplers if it should ever be used beyond the scope of the internship.