### PR TITLE
Add dummy_onehot options. 

### DIFF
--- a/src/garage/envs/task_onehot_wrapper.py
+++ b/src/garage/envs/task_onehot_wrapper.py
@@ -22,7 +22,7 @@ class TaskOnehotWrapper(Wrapper):
 
     """
 
-    def __init__(self, env, task_index, n_total_tasks):
+    def __init__(self, env, task_index, n_total_tasks, dummy_onehot=False):
         assert 0 <= task_index < n_total_tasks
         super().__init__(env)
         self._task_index = task_index
@@ -31,6 +31,7 @@ class TaskOnehotWrapper(Wrapper):
         env_ub = self._env.observation_space.high
         one_hot_ub = np.ones(self._n_total_tasks)
         one_hot_lb = np.zeros(self._n_total_tasks)
+        self._dummy_onehot = dummy_onehot
 
         self._observation_space = akro.Box(
             np.concatenate([env_lb, one_hot_lb]),
@@ -110,7 +111,10 @@ class TaskOnehotWrapper(Wrapper):
 
         """
         one_hot = np.zeros(self._n_total_tasks)
-        one_hot[self._task_index] = 1.0
+        if self._dummy_onehot:
+            one_hot[0] = 1.0
+        else:
+            one_hot[self._task_index] = 1.0
         return np.concatenate([obs, one_hot])
 
     @classmethod

--- a/src/garage/experiment/task_sampler.py
+++ b/src/garage/experiment/task_sampler.py
@@ -254,11 +254,12 @@ class MetaWorldTaskSampler(TaskSampler):
 
     """
 
-    def __init__(self, benchmark, kind, wrapper=None, add_env_onehot=False):
+    def __init__(self, benchmark, kind, wrapper=None, add_env_onehot=False, dummy_onehot=False):
         self._benchmark = benchmark
         self._kind = kind
         self._inner_wrapper = wrapper
         self._add_env_onehot = add_env_onehot
+        self._dummy_onehot = dummy_onehot
         if kind == 'train':
             self._classes = benchmark.train_classes
             self._tasks = benchmark.train_tasks
@@ -337,6 +338,7 @@ class MetaWorldTaskSampler(TaskSampler):
         inner_wrapper = self._inner_wrapper
         add_env_onehot = self._add_env_onehot
         task_indices = self._task_indices
+        dummy_onehot = self._dummy_onehot
 
         def wrap(env, task):
             """Wrap an environment in a metaworld benchmark.
@@ -354,7 +356,8 @@ class MetaWorldTaskSampler(TaskSampler):
             if add_env_onehot:
                 env = TaskOnehotWrapper(env,
                                         task_index=task_indices[task.env_name],
-                                        n_total_tasks=len(task_indices))
+                                        n_total_tasks=len(task_indices), 
+                                        dummy_onehot=dummy_onehot)
             if inner_wrapper is not None:
                 env = inner_wrapper(env, task)
             return env


### PR DESCRIPTION
This overrides the onehot vector in the observation space with zeros except the first one. This should change the mtsac algorithm to original sac.